### PR TITLE
allBoth now respects multi-character non-terminals

### DIFF
--- a/rule-pred.rkt
+++ b/rule-pred.rkt
@@ -22,13 +22,15 @@
             (define str (symbol->string sym))
             ;loop: number --> boolean
             ;purpose: to iterate through the word
-            (define (loop end)
+            (define (loop st end)
               (cond [(zero? end) #t]
-                    [(sub-member combined str (sub1 end) end) (loop (sub1 end))]
-                    [else #f]))
-            ]
-      (if (< (string-length str) 1) #f
-          (loop (string-length str)))))
+                    [(zero? (add1 st)) #f]
+                    [(sub-member combined str st end)
+                     (loop (sub1 st) st)]
+                    [else (loop (sub1 st) end)]))]
+      (let ([e (string-length str)])
+        (if (< e 1) #f
+            (loop (sub1 e) e)))))
 
   ;purpose: to check that the symbol given is composed
   ;         of one symbol from the second list,

--- a/test/fsm/rule-pred.rkt
+++ b/test/fsm/rule-pred.rkt
@@ -10,7 +10,8 @@
                 (test-case "Marco tests"
                            (check-equal? (allBoth 'AbAbA '(A) '(b)) #t)
                            (check-equal? (allBoth 'Abbbbbb '(b A) '()) #t)
-                           (check-equal? (allBoth 'Edeee '(E) '(d i s es)) #f))))
+                           (check-equal? (allBoth 'Edeee '(E) '(d i s es)) #f)
+                           (check-equal? (allBoth 'A-1A-2 '(A-1 A-2) '(a b c)) #t))))
 
   (define oneAndOne-test
     (test-suite "Tests for oneAndOne function"


### PR DESCRIPTION
I add support in `allBoth` for multi-character non-terminals like `A-1035284`. I add a test for that particular scenario. This is a narrow commit, however. If other places were implicitly relying on CFGs` non-terminals also being limited to single-character uppercase symbols, this will introduce downstream bugs. 