### PR TITLE
fix: removed print statement when setting tape posn

### DIFF
--- a/fsm-gui/globals.rkt
+++ b/fsm-gui/globals.rkt
@@ -153,7 +153,6 @@ Created by Joshua Schappel on 12/19/19
   (set! TM-ORIGIONAL-TAPE tape))
 
 (define (set-tm-og-tape-posn posn)
-  (println posn)
   (set! TM-ORIGIONAL-TAPE-POSN posn))
 
 (define (set-init-index-bottom value)


### PR DESCRIPTION
Removes the unnecessary print statement. 