### PR TITLE
fix(gui, gviz): Updated alpha to allow numbers

### DIFF
--- a/fsm-docs/fsm.scrbl
+++ b/fsm-docs/fsm.scrbl
@@ -68,7 +68,7 @@ variable to abstract over the currently read symbol.
 
 
 
-@defidform[alphabet] A list of lowercase symbols with a string representation
+@defidform[alphabet] A list of numbers or lowercase symbols with a string representation
 of length one not including EMP.
 
 @defidform[word]{

--- a/fsm-gui/components/buttonFunctions.rkt
+++ b/fsm-gui/components/buttonFunctions.rkt
@@ -449,17 +449,20 @@ This file contains all the functions associated with a button
 ;; rmvAlpha: world -> world
 ;; Purpose: Removes a letter from the worlds alpha-list
 (define rmvAlpha (lambda (w)
-                   (let ((input-value (string-trim (textbox-text(list-ref (world-input-list w) 1))))
+                   (let* ((input-value (string-trim (textbox-text(list-ref (world-input-list w) 1))))
                          (new-input-list (list-set (world-input-list w) 1 (remove-text (list-ref (world-input-list w) 1) 100)))
-
+                         (to-string (lambda (v) (cond
+                                                  [(symbol? v) (symbol->string v)]
+                                                  [(number? v) (number->string v)]
+                                                  [else (error (format "Can convert value to string. Given ~a" v))])))
                          ;; remove-all: list-of-rules symbol -> list-of-rules
                          ;; Purpose: Removes all rules that are associated with the alpha that is being removed.
                          (remove-all (lambda (lor alpha)
                                        (filter (lambda (x) (case MACHINE-TYPE
                                                              [(tm) #t]
-                                                             [(pda) (not (equal? (symbol->string (cadar x)) alpha))]
                                                              [(tm-language-recognizer) #t]
-                                                             [else (not (equal? (symbol->string (cadr x)) alpha))]))
+                                                             [(pda) (not (equal? (to-string (cadar x)) alpha))]
+                                                             [else (not (equal? (to-string (cadr x)) alpha))]))
                                                lor))))
                      
                      (cond

--- a/fsm-gviz/private/lib.rkt
+++ b/fsm-gviz/private/lib.rkt
@@ -28,7 +28,7 @@
   [add-node (->* (graph? symbol?)
                  (#:atb (hash/c symbol? any/c))
                  graph?)]
-  [add-edge (->* (graph? (or/c list? symbol?) symbol? symbol?)
+  [add-edge (->* (graph? (or/c list? any/c) symbol? symbol?)
                  (#:atb (hash/c symbol? any/c))
                  graph?)]
   [graph->bitmap (-> graph? path? string? image?)]


### PR DESCRIPTION
This PR fixes a bug with graphviz where numbers were not allowed as part of the alphabet. Also updates the docs to be more concise