### PR TITLE
feat(gviz): Now stores dotfiles in the tmp dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 install:
-	@raco make .
+	@raco make main.rkt
 .PHONY: install
 
 test:

--- a/fsm-gviz/interface.rkt
+++ b/fsm-gviz/interface.rkt
@@ -14,6 +14,8 @@
 (define (colorblind-opt? n)
   (and (>= n 0) (<= n 2)))
 
+(define SAVE-DIR (find-tmp-dir))
+
 (provide
  (except-out (all-from-out "private/lib.rkt") stringify-value)
  (all-from-out "private/dot.rkt")
@@ -60,7 +62,7 @@
 ;; converts the fsa to a image
 (define (fsa->bitmap fsa color-blind-mode)
   (graph->bitmap (fsa->graph fsa color-blind-mode)
-                 (current-directory)
+                 SAVE-DIR
                  "vizTool"))
 
 
@@ -92,5 +94,5 @@
                   cur-rule
                   cur-state
                   inv-state)
-                 (current-directory)
+                 SAVE-DIR
                  "vizTool"))

--- a/fsm-gviz/private/dot.rkt
+++ b/fsm-gviz/private/dot.rkt
@@ -1,6 +1,10 @@
 #lang racket
-;; NOTE: this code was coppied from https://github.com/racket/gui/blob/master/gui-lib/mrlib/private/dot.rkt
-(provide find-dot has-dot-executable?)
+;; NOTE: Some of the code in this file was copied from
+;; https://github.com/racket/gui/blob/master/gui-lib/mrlib/private/dot.rkt
+(provide
+ find-dot
+ has-dot-executable?
+ find-tmp-dir)
 
 ;; these paths are explicitly checked (when find-executable-path
 ;; fails) because starting drracket from the finder (or the dock) 
@@ -32,3 +36,22 @@
        (ormap (λ (x) (and (file-exists? (build-path x dot.exe))
                           (build-path x dot.exe)))
               dot-paths)])))
+
+;; find-tmp-dir: path
+;; Looks for the systems tmp directory, if it exists then returns the path to that directory.
+;; If the tmp dir is not found then the current-directory from which the program is ran is used
+;; instead
+;; NOTE: The directory that is returned must have read and write access.
+(define (find-tmp-dir)
+  (define (has-read-write-access? path)
+    (define permissions (file-or-directory-permissions path))
+    (andmap (lambda (p) (member p permissions))
+            '(read write)))
+  (define tmp-dir (find-system-path 'temp-dir))
+  (match tmp-dir
+    [dir #:when (has-read-write-access? dir) dir]
+    ;; If the tmp dir does not have read/write then try the current-dir
+    [dir #:when (and (not (equal? (current-directory) dir))
+                     (has-read-write-access? (current-directory)))
+         (current-directory)]
+    [_ (error (format "Unable to write or read to directory ~s" (path->string tmp-dir)))]))


### PR DESCRIPTION
This PR  tries to store graphviz generated files in the systems `tmp` directory. If this directory does not exist then the current directory is used instead.