### PR TITLE
Gviz node fix

### DIFF
--- a/fsm-gviz/private/lib.rkt
+++ b/fsm-gviz/private/lib.rkt
@@ -205,8 +205,7 @@
     (or (equal? sg n)
         (member n (subgraph-subgraph-list sg) check-subgraph)))
   (if (graph? parent)
-      (or (equal? name (graph-name parent))
-          (member name (graph-node-list parent) (lambda (v n) (equal? (node-name n) v)))
+      (or (member name (graph-node-list parent) (lambda (v n) (equal? (node-name n) v)))
           (member name (graph-subgraph-list parent) check-subgraph))
       (check-subgraph n parent)))
     
@@ -240,7 +239,7 @@
   (define nodes-to-add 
     (map (lambda (n)
            (when (existing-name? parent n)
-             (error "[Duplicate Name]: Node name already exists on the graph"))
+             (error "[Duplicate Name]: Edge name already exists on the graph"))
            (node (clean-string n) (hash-set atb 'label (stringify-value n))))
          names))
   (if (graph? parent)


### PR DESCRIPTION
### Was buggy code:
```racket
(define anbncn (make-tm '(S A B C D E F G H I J K L Y)
                        '(a b c x)
                        `(((S ,BLANK) (J ,RIGHT))
                          ((J ,BLANK) (Y ,BLANK))
                          ((J a) (A ,RIGHT))
                          ((A a) (A ,RIGHT))
                          ((A b) (B ,RIGHT))
                          ((B b) (B ,RIGHT))
                          ((B c) (C ,RIGHT))
                          ((C c) (C ,RIGHT))
                          ((C ,BLANK) (D ,LEFT))
                          ((D a) (D ,LEFT))
                          ((D b) (D ,LEFT))
                          ((D c) (D ,LEFT))
                          ((D x) (D ,LEFT))
                          ((D ,BLANK) (E ,RIGHT))
                          ((E x) (E ,RIGHT))
                          ((E a) (F x))
                          ((E a) (H x))
                          ((F a) (F ,RIGHT))
                          ((F b) (G x))
                          ((F x) (F ,RIGHT))
                          ((G b) (G ,RIGHT))
                          ((G x) (G ,RIGHT))
                          ((G c) (D x))
                          ((H x) (H ,RIGHT))
                          ((H b) (I x))
                          ((I x) (I ,RIGHT))
                          ((I c) (K x))            
                          ((K x) (L ,RIGHT))  
                          ((L ,BLANK) (Y ,BLANK)))     
                        'S
                        '(Y)
                        'Y))
```