### PR TITLE
Word generation no longer hangs after exceeding maximum number of possible combinations

### DIFF
--- a/fsm-core/private/word.rkt
+++ b/fsm-core/private/word.rkt
@@ -47,8 +47,19 @@
   
   ; natnum alphabet (listof word) --> (listof word)
   (define (generate-words n sigma words)
-    (cond [(= n 0) words]
+    (define sigma-len (length sigma))
+    (define (calculate-max-len i)
+      (cond [(>= i 0) (+ (expt sigma-len i) (calculate-max-len (- i 1)))]
+          [else 0]))
+    (define max-len (calculate-max-len (- MAX-WORD-LENGTH 1)))
+    (generate-words-limited n sigma words max-len))
+
+  (define (generate-words-limited n sigma words max-len)
+    (cond [(>= (length words) max-len) words]
+          [(= n 0) words]
           [else (let ((w (generate-word sigma)))
-                  (cond [(member w words) (generate-words n sigma words)]
-                        [else (generate-words (- n 1) sigma (cons w words))]))]))
+                  (cond [(member w words) (generate-words-limited n sigma words max-len)]
+                        [else (generate-words-limited (- n 1) sigma (cons w words) max-len)]))]))
   )
+
+  

--- a/fsm-test/fsm-core/fsm-tests.rkt
+++ b/fsm-test/fsm-core/fsm-tests.rkt
@@ -810,9 +810,9 @@
   (define CSG-an-bn-an-bn-cn (grammar-concat CSG-an-bn CSG-an-bn-cn))
 
   (check-equal? (last (grammar-derive CSG-an-bn-an-bn-cn '())) 
-                  EMP)
+                EMP)
   (check-equal? (last (grammar-derive CSG-an-bn-an-bn-cn '(a a b b a b c)))
-                  'aabbabc)
+                'aabbabc)
 
   ;NOTE WE DONT CHECK FOR NOT IN THE GRAMMAR BCZ IT MAY NEVER END
   (define RENAME-CSG-an-bn-cn (grammar-rename-nts (grammar-nts CSG-an-bn-cn) 
@@ -902,6 +902,39 @@
   (check-equal? regexp-nota*Unotb* "(b*a(a ∪ b)* ∪ a*b(a ∪ b)*)")
 
 
+  ;;Testing no-hang at maximum unique combinations for a given alphabet
+  ;;Passing these tests is just to ensure that the program runs
+  ;; since the issue tested by these was an infinte loop
+  (define MAX-TEST (make-dfa
+                          '(Z F S T O M)
+                          '(a)
+                          'Z
+                          '(Z F S T O)
+                          '((Z a F)
+                            (F a S)
+                            (S a T)
+                            (T a O)
+                            (O a M)
+                            (M a M))
+                          'no-dead))
 
+  (check-false (null? (sm-test MAX-TEST)))
+  (check-false (null? (sm-test MAX-TEST 10)))
+  (check-false (null? (sm-test MAX-TEST 11)))
+
+  (define MAX-TEST-TWO (make-dfa
+                    '(Z H)
+                    '(a b)
+                    'Z
+                    '(H)
+                    '((Z a H)
+                      (Z b H)
+                      (H a Z)
+                      (H b Z))
+                    'no-dead))
+
+  (check-false (null? (sm-test MAX-TEST-TWO)))
+  (check-false (null? (sm-test MAX-TEST-TWO 1023)))
+  (check-false (null? (sm-test MAX-TEST-TWO 1024)))
 
   ) ;; end module+ test 


### PR DESCRIPTION
Originally the word generation would generate its maximum possible number of combinations which was:
The sum of all x^n n = 0-9 and x = the number of letters in the alphabet

Once this was reached it would loop infinitely attempting to generate a new combination, it would fail to be unique and then it would try again. Now that the maximum number of combinations are calculated and then passed along to be checked for and if the number of combinations has exceeded that it stops the generation.