### PR TITLE
Fix accept/reject errors

### DIFF
--- a/fsm-core/private/macros/validation/validation-flat-contracts.rkt
+++ b/fsm-core/private/macros/validation/validation-flat-contracts.rkt
@@ -63,7 +63,8 @@
                       (raise-blame-error
                        blame
                        (invalid-words words sigma)
-                       (format "Step six of the design recipe has not been successfully completed.\nThe following words the machine should ~a contain symbols not included in sigma" field)
+                       (format "Step six of the design recipe has not been successfully completed.
+The following words the machine should ~a contain symbols not included in sigma" field)
                        )
                       )
                     )
@@ -80,8 +81,8 @@
                       (raise-blame-error
                        blame
                        (invalid-words-tm words sigma)
-                       (format-error blame "Step six of the design recipe has not been successfully completed.\nThe following words the machine should ~a contain symbols not included in sigma" field)
-                     
+                       (format "Step six of the design recipe has not been successfully completed.
+The following words the machine should ~a contain symbols not included in sigma" field)
                        )
                       )
                     )
@@ -99,7 +100,6 @@
                        blame
                        (unacceptable-position words)
                        (format "The following words have positions that are not valid in their list of words")
-                     
                        )
                       )
                     )

--- a/fsm-test/fsm-core/tests/tm-tests.rkt
+++ b/fsm-test/fsm-core/tests/tm-tests.rkt
@@ -372,7 +372,30 @@ The constructed machine does not reject the following words:  ((@ _ a b c))"))
                (format "Step six of the design recipe has not been successfully completed.
 The constructed machine does not accept the following words:  ((@ _ a b c c))"))
   
-  ;;RULES
+  ;;ACCEPTS/REJECTS
+  (check-error (make-tm '(S Y N)
+                    '(a b)
+                    `(((S a) (S ,RIGHT))
+                      ((S b) (N b))
+                      ((S ,BLANK) (Y ,BLANK)))
+                    'S
+                    '(Y N)
+                    'Y
+                    #:accepts '((c)))
+                (format "Step six of the design recipe has not been successfully completed.
+The following words the machine should accept contain symbols not included in sigma: ((c))"))
+
+  (check-error (make-tm '(S Y N)
+                    '(a b)
+                    `(((S a) (S ,RIGHT))
+                      ((S b) (N b))
+                      ((S ,BLANK) (Y ,BLANK)))
+                    'S
+                    '(Y N)
+                    'Y
+                    #:rejects '((c)))
+                (format "Step six of the design recipe has not been successfully completed.
+The following words the machine should reject contain symbols not included in sigma: ((c))"))
   
   (test)
   


### PR DESCRIPTION
Updates formatting of the error messages for invalid words in the accept/rejects lists. Also, fixes error formatting logic for TM accept/reject error (use `format` instead of `format-error`)