### PR TITLE
fixed more error strings

### DIFF
--- a/fsm-core/private/fsmunit/check-accept-reject-failure-strings.rkt
+++ b/fsm-core/private/fsmunit/check-accept-reject-failure-strings.rkt
@@ -215,25 +215,25 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; GRAMMAR REJECT ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (named-single-failure-grammar-reject grammar-name invalid-word)
-  (format "Step 6 of the design recipe has not been successfully completed. The constructed machine, ~s, derives the following word:\n~a"
+  (format "Step 6 of the design recipe has not been successfully completed. The constructed grammar, ~s, derives the following word:\n~a"
           grammar-name
           invalid-word))
 
 (define (named-multi-failure-grammar-reject grammar-name invalid-words)
   (foldl (lambda (val accum)
            (string-append accum (format "\n~s" val)))
-         (format "Step 6 of the design recipe has not been successfully completed. The constructed machine, ~s, derives the following words:"
+         (format "Step 6 of the design recipe has not been successfully completed. The constructed grammar, ~s, derives the following words:"
                  grammar-name)
          invalid-words))
 
 (define (anonymous-single-failure-grammar-reject invalid-word)
-  (format "Step 6 of the design recipe has not been successfully completed. The constructed machine derives the following word:\n~a"
+  (format "Step 6 of the design recipe has not been successfully completed. The constructed grammar derives the following word:\n~a"
           invalid-word))
 
 (define (anonymous-multi-failure-grammar-reject invalid-words)
   (foldl (lambda (val accum)
            (string-append accum (format "\n~s" val)))
-         "Step 6 of the design recipe has not been successfully completed. The constructed machine derives the following words:"
+         "Step 6 of the design recipe has not been successfully completed. The constructed grammar derives the following words:"
          invalid-words))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; GRAMMAR INVALID NONTERMINALS ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/fsm-core/private/fsmunit/check-macro-tests-failing.rkt
+++ b/fsm-core/private/fsmunit/check-macro-tests-failing.rkt
@@ -20,7 +20,7 @@ E - ci = ab* final
 
 |#
 
-
+#|
 (define AB*B*UAB*
   (make-ndfa '(S K B C H)
              '(a b)
@@ -2574,3 +2574,5 @@ Y - w=x* AND [xs] remainder 3 = 0, final accepting state
               '(a a a b a a a)
               '(a a b b a a)
               '(b b a b b))
+
+|#


### PR DESCRIPTION
check-derive and check-not-derive no longer refer to machines in the error messages.