### PR TITLE
Update wording of NDFA rule structure error

### DIFF
--- a/fsm-core/private/macros/constructors.rkt
+++ b/fsm-core/private/macros/constructors.rkt
@@ -103,7 +103,7 @@
                                   (no-duplicates/c "final states" "three"))]
           [rules (states
                   sigma) (and/c (is-a-list/c "machine rules" "four")
-                                correct-dfa-rule-structures/c
+                                correct-ndfa-rule-structures/c
                                 (correct-dfa-rules/c states (cons EMP sigma))
                                 (no-duplicates/c "rules" "four"))]
           )

--- a/fsm-core/private/macros/rules/rules-flat-contracts.rkt
+++ b/fsm-core/private/macros/rules/rules-flat-contracts.rkt
@@ -8,6 +8,7 @@
          correct-members/c
          correct-dfa-rules/c
          correct-dfa-rule-structures/c
+         correct-ndfa-rule-structures/c
          correct-ndpda-rules/c
          correct-ndpda-rule-structures/c
          correct-tm-rules/c
@@ -96,6 +97,25 @@
                      blame
                      (list (car (incorrect-dfa-rules states sigma rules)))
                      (format "~a\nThe following rules have errors" design-recipe-message))))))
+
+;correct-ndfa-rule-structures/c: contract
+;predicate: (listof x) -> boolean
+;purpose: Ensures that every element in the list is structured as a valid ndfa rule.
+; It checks each rule to see that it is a (list state alphabet state)
+(define correct-ndfa-rule-structures/c
+  (make-flat-contract
+   #:name 'correct-dfa-rule-structures
+   #:first-order (lambda (rules)  (empty? (incorrect-ndfa-rule-structures rules)))
+   #:projection (lambda (blame)
+                  (lambda (rules)
+                    (current-blame-format format-incorrect-rules-error)
+                    (if (empty? (incorrect-ndfa-rule-structures rules))
+                        rules
+                        (raise-blame-error
+                         blame
+                         (list (car (incorrect-ndfa-rule-structures rules)))
+                         (format "~a\nThe following rules have structural errors" design-recipe-message)))
+                    ))))
 
 ;correct-ndpda-rule-structures/c: contract
 ;predicate: (listof x) -> boolean

--- a/fsm-core/private/macros/rules/rules-predicates.rkt
+++ b/fsm-core/private/macros/rules/rules-predicates.rkt
@@ -13,6 +13,7 @@
          incorrect-tm-rules
          incorrect-mttm-rules
          incorrect-dfa-rule-structures
+         incorrect-ndfa-rule-structures
          incorrect-ndpda-rule-structures
          incorrect-tm-rule-structures
          incorrect-mttm-rule-structures
@@ -292,6 +293,31 @@
                   '())))
     (if (empty? all-errors) '() (list (make-invalid-rule rule all-errors))))
   (flatten (map rule-with-errors rules)))
+
+;incorrect-ndfa-rule-structures: (listof any) --> (listof invalid-rule)
+;purpose: filters the input list of elements, such that any element that is not structured
+; as a valid dfa-rule is returned as an invalid-rule struct containing all the offenses.
+(define (incorrect-ndfa-rule-structures elems)
+  (define (rule-with-errors elem)
+    (define all-errors
+      (cond [(or (not (list? elem)) (not (= (length elem) 3)))
+             (list (format "The given rule, ~a, does not have the correct structure. An NDFA rule must be a list with three elements." elem))]
+            [else
+             (append (if (valid-state? (first elem))
+                         '()
+                         (list (format "The first element in the rule, ~a, is not a valid state." (first elem))))
+                     (if (valid-dfa-symbol? (second elem))
+                         '()
+                         (list (format "The second element in the rule, ~a, is not a valid alphabet element." (second elem))))
+                     (if (valid-state? (third elem))
+                         '()
+                         (list (format "The third element in the rule, ~a, is not a valid state." (third elem)))))]
+            )
+      )
+    (if (empty? all-errors) '() (list (make-invalid-rule elem all-errors)))
+    )
+  (flatten (map rule-with-errors elems))
+  )
 
 ;with-indices: (listof x) --> (listof (list x natnum))
 ;Purpose: Returns the input list, but each element is paired with its index


### PR DESCRIPTION
Constructing an NDFA with an incorrect rule used to return an error referencing DFA rules. This has been changed to now correctly reference NDFA rules.